### PR TITLE
[frontend] refactor Aptogotchi

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.10.1",
+    "sonner": "^1.4.41",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@aptos-labs/ts-sdk':
     specifier: ^1.5.1
@@ -46,6 +50,9 @@ dependencies:
   react-icons:
     specifier: ^4.10.1
     version: 4.10.1(react@18.2.0)
+  sonner:
+    specifier: ^1.4.41
+    version: 1.4.41(react-dom@18.2.0)(react@18.2.0)
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
@@ -249,6 +256,7 @@ packages:
 
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -3490,6 +3498,16 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
     dev: true
+
+  /sonner@1.4.41(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-uG511ggnnsw6gcn/X+YKkWPo5ep9il9wYi3QJxHsYe7yTZ4+cOd1wuodOUmOpFuXL+/RE3R04LczdNCDygTDgQ==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4,7 +4,6 @@
 
 *, ::before, ::after {
   box-sizing: border-box;
-  word-spacing: -0.25rem;
 }
 
 body {

--- a/frontend/src/app/home/Connected.tsx
+++ b/frontend/src/app/home/Connected.tsx
@@ -1,45 +1,55 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useEffect, useCallback } from "react";
 import { Pet } from "./Pet";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { Mint } from "./Mint";
 import { getAptosClient } from "@/utils/aptosClient";
 import { Modal } from "@/components/Modal";
 import { ABI } from "@/utils/abi";
+import { usePet } from "@/context/PetContext";
 
 const TESTNET_ID = "2";
 
 const aptosClient = getAptosClient();
 
 export function Connected() {
-  const [pet, setPet] = useState<Pet>();
+  const { pet, setPet } = usePet();
   const { account, network } = useWallet();
 
   const fetchPet = useCallback(async () => {
     if (!account?.address) return;
 
-    const [hasPet] = await aptosClient.view({
+    const hasPet = await aptosClient.view({
       payload: {
         function: `${ABI.address}::main::has_aptogotchi`,
         functionArguments: [account.address],
       },
     });
-    if (hasPet as boolean) {
-      const response = await aptosClient.view({
-        payload: {
-          function: `${ABI.address}::main::get_aptogotchi`,
-          functionArguments: [account.address],
-        },
-      });
-      const [name, birthday, energyPoints, parts] = response;
-      const typedParts = parts as { body: number; ear: number; face: number };
-      setPet({
-        name: name as string,
-        birthday: birthday as number,
-        energy_points: energyPoints as number,
-        parts: typedParts,
-      });
+
+    if (hasPet) {
+      let response;
+
+      try {
+        response = await aptosClient.view({
+          payload: {
+            function: `${ABI.address}::main::get_aptogotchi`,
+            functionArguments: [account.address],
+          },
+        });
+
+        const [name, birthday, energyPoints, parts] = response;
+        const typedParts = parts as { body: number; ear: number; face: number };
+
+        setPet({
+          name: name as string,
+          birthday: birthday as number,
+          energy_points: energyPoints as number,
+          parts: typedParts,
+        });
+      } catch (error) {
+        console.error(error);
+      }
     }
   }, [account?.address]);
 
@@ -52,7 +62,7 @@ export function Connected() {
   return (
     <div className="flex flex-col gap-3 p-3">
       {network?.chainId !== TESTNET_ID && <Modal />}
-      {pet ? <Pet pet={pet} setPet={setPet} /> : <Mint fetchPet={fetchPet} />}
+      {pet ? <Pet /> : <Mint fetchPet={fetchPet} />}
     </div>
   );
 }

--- a/frontend/src/app/home/NotConnected.tsx
+++ b/frontend/src/app/home/NotConnected.tsx
@@ -16,7 +16,7 @@ export function NotConnected() {
   return (
     <div className="flex flex-col gap-6 p-6">
       <ShufflePetImage petParts={petParts} setPetParts={setPetParts} />
-      <div className="nes-container is-dark with-title">
+      <div className="nes-container is-dark with-title text-sm sm:text-base">
         <p className="title">Welcome</p>
         <p>{text}</p>
       </div>

--- a/frontend/src/app/home/Pet/Actions.tsx
+++ b/frontend/src/app/home/Pet/Actions.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { Dispatch, SetStateAction, useState } from "react";
+import { useState } from "react";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import { Pet } from ".";
 import { getAptosClient } from "@/utils/aptosClient";
 import {
   NEXT_PUBLIC_ENERGY_CAP,
@@ -11,24 +10,20 @@ import {
 } from "@/utils/env";
 import { ABI } from "@/utils/abi";
 import { toast } from "sonner";
+import { usePet } from "@/context/PetContext";
 
 const aptosClient = getAptosClient();
 
 export type PetAction = "feed" | "play";
 
 export interface ActionsProps {
-  pet: Pet;
   selectedAction: PetAction;
   setSelectedAction: (action: PetAction) => void;
-  setPet: Dispatch<SetStateAction<Pet | undefined>>;
 }
 
-export function Actions({
-  selectedAction,
-  setSelectedAction,
-  setPet,
-  pet,
-}: ActionsProps) {
+export function Actions({ selectedAction, setSelectedAction }: ActionsProps) {
+  const { pet, setPet } = usePet();
+
   const [transactionInProgress, setTransactionInProgress] =
     useState<boolean>(false);
   const { account, network, signAndSubmitTransaction } = useWallet();
@@ -79,7 +74,7 @@ export function Actions({
       toast.error("Failed to feed your pet. Please try again.");
     } finally {
       setTransactionInProgress(false);
-      toast.success(`Thanks for feeding your pet, ${pet.name}!`);
+      toast.success(`Thanks for feeding your pet, ${pet?.name}!`);
     }
   };
 
@@ -117,15 +112,15 @@ export function Actions({
       toast.error("Failed to play with your pet. Please try again.");
     } finally {
       setTransactionInProgress(false);
-      toast.success(`Thanks for playing with your pet, ${pet.name}!`);
+      toast.success(`Thanks for playing with your pet, ${pet?.name}!`);
     }
   };
 
   const feedDisabled =
     selectedAction === "feed" &&
-    pet.energy_points === Number(NEXT_PUBLIC_ENERGY_CAP);
+    pet?.energy_points === Number(NEXT_PUBLIC_ENERGY_CAP);
   const playDisabled =
-    selectedAction === "play" && pet.energy_points === Number(0);
+    selectedAction === "play" && pet?.energy_points === Number(0);
 
   return (
     <div className="nes-container with-title flex-1 bg-white h-[320px]">

--- a/frontend/src/app/home/Pet/Actions.tsx
+++ b/frontend/src/app/home/Pet/Actions.tsx
@@ -10,6 +10,7 @@ import {
   NEXT_PUBLIC_ENERGY_INCREASE,
 } from "@/utils/env";
 import { ABI } from "@/utils/abi";
+import { toast } from "sonner";
 
 const aptosClient = getAptosClient();
 
@@ -75,8 +76,10 @@ export function Actions({
       });
     } catch (error: any) {
       console.error(error);
+      toast.error("Failed to feed your pet. Please try again.");
     } finally {
       setTransactionInProgress(false);
+      toast.success(`Thanks for feeding your pet, ${pet.name}!`);
     }
   };
 
@@ -111,8 +114,10 @@ export function Actions({
       });
     } catch (error: any) {
       console.error(error);
+      toast.error("Failed to play with your pet. Please try again.");
     } finally {
       setTransactionInProgress(false);
+      toast.success(`Thanks for playing with your pet, ${pet.name}!`);
     }
   };
 

--- a/frontend/src/app/home/Pet/Details.tsx
+++ b/frontend/src/app/home/Pet/Details.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { AiFillSave } from "react-icons/ai";
-import { FaCopy } from "react-icons/fa";
+import { FaCopy, FaExternalLinkAlt } from "react-icons/fa";
 import { HealthBar } from "@/components/HealthBar";
 import { Pet } from ".";
 import { Dispatch, SetStateAction, useState } from "react";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { getAptosClient } from "@/utils/aptosClient";
 import { ABI } from "@/utils/abi";
+import { toast } from "sonner";
 
 export interface PetDetailsProps {
   pet: Pet;
@@ -45,11 +46,17 @@ export function PetDetails({ pet, setPet }: PetDetailsProps) {
       });
     } catch (error: any) {
       console.error(error);
+      toast.error("Failed to update name. Please try again.");
+    } finally {
+      toast.success(
+        `Name was successfully updated from ${pet.name} to ${newName}!`
+      );
     }
   };
 
   const handleCopyOwnerAddrOrName = () => {
     navigator.clipboard.writeText(owner);
+    toast.success("Owner address copied to clipboard.");
   };
 
   const nameFieldComponent = (
@@ -76,7 +83,16 @@ export function PetDetails({ pet, setPet }: PetDetailsProps) {
 
   const ownerFieldComponent = (
     <div className="nes-field">
-      <label htmlFor="owner_field">Owner</label>
+      <a
+        className="flex items-center gap-2"
+        href={`https://explorer.aptoslabs.com/account/${owner}?network=testnet`}
+        target="_blank"
+      >
+        <label htmlFor="owner_field" className="mb-0">
+          Owner
+        </label>
+        <FaExternalLinkAlt className="h-4 w-4 drop-shadow-sm" />
+      </a>
       <div className="relative">
         <input
           type="text"

--- a/frontend/src/app/home/Pet/Details.tsx
+++ b/frontend/src/app/home/Pet/Details.tsx
@@ -3,28 +3,25 @@
 import { AiFillSave } from "react-icons/ai";
 import { FaCopy, FaExternalLinkAlt } from "react-icons/fa";
 import { HealthBar } from "@/components/HealthBar";
-import { Pet } from ".";
-import { Dispatch, SetStateAction, useState } from "react";
+import { useState } from "react";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { getAptosClient } from "@/utils/aptosClient";
 import { ABI } from "@/utils/abi";
 import { toast } from "sonner";
-
-export interface PetDetailsProps {
-  pet: Pet;
-  setPet: Dispatch<SetStateAction<Pet | undefined>>;
-}
+import { usePet } from "@/context/PetContext";
 
 const aptosClient = getAptosClient();
 
-export function PetDetails({ pet, setPet }: PetDetailsProps) {
-  const [newName, setNewName] = useState(pet.name);
+export function PetDetails() {
+  const { pet, setPet } = usePet();
+
+  const [newName, setNewName] = useState<string>(pet?.name || "");
   const { account, network, signAndSubmitTransaction } = useWallet();
   const owner = account?.ansName
     ? `${account?.ansName}.apt`
     : account?.address || "";
 
-  const canSave = newName !== pet.name;
+  const canSave = newName !== pet?.name;
 
   const handleNameChange = async () => {
     if (!account || !network) return;
@@ -49,7 +46,7 @@ export function PetDetails({ pet, setPet }: PetDetailsProps) {
       toast.error("Failed to update name. Please try again.");
     } finally {
       toast.success(
-        `Name was successfully updated from ${pet.name} to ${newName}!`
+        `Name was successfully updated from ${pet?.name} to ${newName}!`
       );
     }
   };
@@ -117,7 +114,7 @@ export function PetDetails({ pet, setPet }: PetDetailsProps) {
         <label>Energy Points</label>
         <HealthBar
           totalHealth={10}
-          currentHealth={pet.energy_points}
+          currentHealth={pet?.energy_points || 0}
           icon="star"
         />
       </div>

--- a/frontend/src/app/home/Pet/Image.tsx
+++ b/frontend/src/app/home/Pet/Image.tsx
@@ -6,12 +6,15 @@ import { PetAction } from "@/app/home/Pet/Actions";
 
 export interface PetImageProps {
   selectedAction?: PetAction;
-  petParts: PetParts;
+  petParts: PetParts | undefined;
   avatarStyle?: boolean;
 }
 
 export function PetImage(props: PetImageProps) {
   const { avatarStyle, petParts, selectedAction } = props;
+
+  if (!petParts) return <div className="h-80 w-80 bg-gray-200"></div>;
+
   const head = BASE_PATH + "head.png";
   const body = BASE_PATH + bodies[petParts.body];
   const ear = BASE_PATH + ears[petParts.ear];

--- a/frontend/src/app/home/Pet/ShufflePetImage.tsx
+++ b/frontend/src/app/home/Pet/ShufflePetImage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Pet, PetParts } from ".";
+import { PetParts } from ".";
 import { PetImage } from "./Image";
 import { ShuffleButton } from "@/components/ShuffleButton";
 import {

--- a/frontend/src/app/home/Pet/Summary.tsx
+++ b/frontend/src/app/home/Pet/Summary.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useTypingEffect } from "@/utils/useTypingEffect";
-import { Pet } from ".";
+import { usePet } from "@/context/PetContext";
 
-export interface SummaryProps {
-  pet: Pet;
-}
+export function Summary() {
+  const { pet } = usePet();
 
-export function Summary({ pet }: SummaryProps) {
+  if (!pet) return null;
+
   let text = `${pet.name} is doing great! 😄`;
 
   if (pet.energy_points >= 8) {

--- a/frontend/src/app/home/Pet/index.tsx
+++ b/frontend/src/app/home/Pet/index.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Dispatch, SetStateAction, useState } from "react";
+import { useState } from "react";
 import { Actions, PetAction } from "./Actions";
 import { PetDetails } from "./Details";
 import { PetImage } from "./Image";
 import { Summary } from "./Summary";
 import { AptogotchiCollection } from "@/components/AptogotchiCollection";
+import { usePet } from "@/context/PetContext";
 
 export interface Pet {
   name: string;
@@ -30,12 +31,9 @@ export const DEFAULT_PET = {
   },
 };
 
-interface PetProps {
-  pet: Pet;
-  setPet: Dispatch<SetStateAction<Pet | undefined>>;
-}
+export function Pet() {
+  const { pet, setPet } = usePet();
 
-export function Pet({ pet, setPet }: PetProps) {
   const [selectedAction, setSelectedAction] = useState<PetAction>("play");
 
   return (
@@ -44,19 +42,17 @@ export function Pet({ pet, setPet }: PetProps) {
         <div className="flex flex-col gap-2 sm:gap-4 sm:w-[360px] m-auto">
           <PetImage
             selectedAction={selectedAction}
-            petParts={pet.parts}
+            petParts={pet?.parts}
             avatarStyle
           />
-          <PetDetails pet={pet} setPet={setPet} />
+          <PetDetails />
         </div>
         <div className="flex flex-col gap-2 sm:gap-8 sm:w-[680px] h-full">
           <Actions
             selectedAction={selectedAction}
             setSelectedAction={setSelectedAction}
-            setPet={setPet}
-            pet={pet}
           />
-          <Summary pet={pet} />
+          <Summary />
         </div>
       </div>
       <AptogotchiCollection />

--- a/frontend/src/app/home/Pet/index.tsx
+++ b/frontend/src/app/home/Pet/index.tsx
@@ -39,9 +39,9 @@ export function Pet({ pet, setPet }: PetProps) {
   const [selectedAction, setSelectedAction] = useState<PetAction>("play");
 
   return (
-    <div className="flex flex-col self-center m-10">
-      <div className="flex flex-row self-center gap-12">
-        <div className="flex flex-col gap-4 w-[360px]">
+    <div className="flex flex-col self-center m-2 sm:m-10">
+      <div className="flex flex-col sm:flex-row self-center gap-4 sm:gap-12">
+        <div className="flex flex-col gap-2 sm:gap-4 sm:w-[360px] m-auto">
           <PetImage
             selectedAction={selectedAction}
             petParts={pet.parts}
@@ -49,7 +49,7 @@ export function Pet({ pet, setPet }: PetProps) {
           />
           <PetDetails pet={pet} setPet={setPet} />
         </div>
-        <div className="flex flex-col gap-8 w-[680px] h-full">
+        <div className="flex flex-col gap-2 sm:gap-8 sm:w-[680px] h-full">
           <Actions
             selectedAction={selectedAction}
             setSelectedAction={setSelectedAction}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { PropsWithChildren } from "react";
 import { GeoTargetly } from "@/utils/GeoTargetly";
 import "nes.css/css/nes.min.css";
 import { Toaster } from "sonner";
+import { PetProvider } from "@/context/PetContext";
 import "./globals.css";
 
 const kongtext = localFont({
@@ -52,7 +53,9 @@ export default function RootLayout({ children }: PropsWithChildren) {
           closeButton
           expand={true}
         />
-        <WalletProvider>{children}</WalletProvider>
+        <PetProvider>
+          <WalletProvider>{children}</WalletProvider>
+        </PetProvider>
         <GeoTargetly />
       </body>
     </html>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import localFont from "next/font/local";
 import { PropsWithChildren } from "react";
 import { GeoTargetly } from "@/utils/GeoTargetly";
 import "nes.css/css/nes.min.css";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const kongtext = localFont({
@@ -38,6 +39,19 @@ export default function RootLayout({ children }: PropsWithChildren) {
         />
       </head>
       <body className={kongtext.className}>
+        <Toaster
+          richColors
+          position="top-right"
+          toastOptions={{
+            style: {
+              letterSpacing: "0.02em",
+            },
+            className: "toast",
+            duration: 5000,
+          }}
+          closeButton
+          expand={true}
+        />
         <WalletProvider>{children}</WalletProvider>
         <GeoTargetly />
       </body>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,44 +1,21 @@
 import dynamic from "next/dynamic";
 import { Body } from "./home/Body";
-import { PropsWithChildren } from "react";
-
-const FixedSizeWrapper = ({ children }: PropsWithChildren) => {
-  const fixedStyle = {
-    width: "1200px",
-    height: "800px",
-    border: "6px solid",
-    margin: "auto",
-  };
-
-  return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        height: "100vh",
-      }}
-    >
-      <div style={fixedStyle}>{children}</div>
-    </div>
-  );
-};
 
 export default function Home() {
   return (
-    <main className="flex flex-col">
-      <FixedSizeWrapper>
+    <div className="flex sm:justify-center sm:items-center sm:h-screen sm:overflow-hidden">
+      <div className="w-screen sm:w-[1200px] sm:h-[800px] sm:m-auto border-4 border-black border-solid">
         <Header />
         <Body />
-      </FixedSizeWrapper>
-    </main>
+      </div>
+    </div>
   );
 }
 
 function Header() {
   return (
-    <header className="sticky top-0 z-10 flex justify-between items-center px-6 py-4 bg-gradient-to-r from-orange-300 via-orange-400 to-red-400 shadow-md w-full gap-2">
-      <h1 className="text-2xl">Aptogotchi</h1>
+    <header className="md:sticky top-0 z-10 flex justify-between items-center md:px-6 py-4 bg-gradient-to-r from-orange-300 via-orange-400 to-red-400 shadow-md w-full gap-2">
+      <h1 className="text-2xl hidden sm:block">Aptogotchi</h1>
       <WalletButtons />
     </header>
   );

--- a/frontend/src/components/AptogotchiCollection/index.tsx
+++ b/frontend/src/components/AptogotchiCollection/index.tsx
@@ -15,7 +15,7 @@ export function AptogotchiCollection() {
   if (loading || !collection) return null;
 
   return (
-    <div className="nes-container with-title h-[100px]">
+    <div className="nes-container with-title sm:h-[100px]">
       <p>{`There are a total of ${collection.current_supply} Aptogotchis in existence.`}</p>
       <p>{`Meet your fellow Aptogotchis: ${firstFewAptogotchiName?.join(", ")}${
         (firstFewAptogotchiName?.length || 0) < collection.current_supply

--- a/frontend/src/components/WalletButtons/index.tsx
+++ b/frontend/src/components/WalletButtons/index.tsx
@@ -8,18 +8,30 @@ import {
   WalletName,
 } from "@aptos-labs/wallet-adapter-react";
 import { cn } from "@/utils/styling";
+import { toast } from "sonner";
 
 const buttonStyles = "nes-btn is-primary";
 
 export const WalletButtons = () => {
   const { wallets, connected, disconnect, isLoading } = useWallet();
 
+  const onWalletDisconnectRequest = async () => {
+    try {
+      disconnect();
+    } catch (error) {
+      console.warn(error);
+      toast.error("Failed to disconnect wallet. Please try again.");
+    } finally {
+      toast.success("Wallet successfully disconnected!");
+    }
+  };
+
   if (connected) {
     return (
       <div className="flex flex-row">
         <div
           className={cn(buttonStyles, "hover:bg-blue-700 btn-small")}
-          onClick={disconnect}
+          onClick={onWalletDisconnectRequest}
         >
           Disconnect
         </div>
@@ -50,7 +62,9 @@ const WalletView = ({ wallet }: { wallet: Wallet }) => {
       await connect(walletName);
     } catch (error) {
       console.warn(error);
-      window.alert("Failed to connect wallet");
+      toast.error("Failed to connect wallet. Please try again.");
+    } finally {
+      toast.success("Wallet successfully connected!");
     }
   };
 

--- a/frontend/src/components/WalletButtons/index.tsx
+++ b/frontend/src/components/WalletButtons/index.tsx
@@ -28,7 +28,7 @@ export const WalletButtons = () => {
 
   if (connected) {
     return (
-      <div className="flex flex-row">
+      <div className="flex flex-row m-auto sm:m-0 sm:px-4">
         <div
           className={cn(buttonStyles, "hover:bg-blue-700 btn-small")}
           onClick={onWalletDisconnectRequest}

--- a/frontend/src/components/WalletButtons/index.tsx
+++ b/frontend/src/components/WalletButtons/index.tsx
@@ -10,7 +10,7 @@ import {
 import { cn } from "@/utils/styling";
 import { toast } from "sonner";
 
-const buttonStyles = "nes-btn is-primary";
+const buttonStyles = "nes-btn is-primary m-auto sm:m-0 sm:px-4";
 
 export const WalletButtons = () => {
   const { wallets, connected, disconnect, isLoading } = useWallet();

--- a/frontend/src/context/PetContext.tsx
+++ b/frontend/src/context/PetContext.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  Dispatch,
+  SetStateAction,
+} from "react";
+import { Pet } from "@/app/home/Pet";
+
+interface PetContextType {
+  pet: Pet | undefined;
+  setPet: Dispatch<SetStateAction<Pet | undefined>>;
+}
+
+const PetContext = createContext<PetContextType | undefined>(undefined);
+
+export const PetProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [pet, setPet] = useState<Pet | undefined>(undefined);
+
+  return (
+    <PetContext.Provider value={{ pet, setPet }}>
+      {children}
+    </PetContext.Provider>
+  );
+};
+
+export const usePet = () => {
+  const context = useContext(PetContext);
+  if (!context) {
+    throw new Error("usePet must be used within a PetProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
## Description
Copying over some changes from [aptogotchi-keyless](https://github.com/darren-wangg/aptogotchi-keyless):
- add [Toast](https://sonner.emilkowal.ski/) component
- mobile/responsive styling and optimizations
- create `Pet` provider, instead of passing around `pet` & `setPet` as props

## Test Plan
- [x] mobile

https://github.com/aptos-labs/aptogotchi/assets/50218308/6b616bfb-a90b-486f-9c90-87c64c323393